### PR TITLE
feat: yank package support

### DIFF
--- a/src/utils/vpm.ts
+++ b/src/utils/vpm.ts
@@ -51,11 +51,9 @@ export const getAllPackages = (repositories: VPMRepository[]) => {
 }
 
 export const isYanked = (pkg: VPMPackage) => {
-  console.log(`Checking yanked for ${pkg.name}@${pkg.version}`)
   const yank = pkg['vrc-get']?.['yanked'];
   const yanked = typeof yank === 'string' || yank === true;
-  console.log(`Yanked: ${yanked}`)
-  return typeof yank === 'string' || yank === true;
+  return yanked;
 }
 
 /**

--- a/src/utils/vpm.ts
+++ b/src/utils/vpm.ts
@@ -18,6 +18,8 @@ export interface VPMPackage extends UPMPackage {
   legacyFolders: { [key: string]: string; } | undefined,
   legacyFiles: { [key: string]: string; } | undefined,
   legacyPackages: string[] | undefined,
+  // vrc-get extension for yank support
+  'vrc-get'? : { yanked?: boolean | string; }
 }
 
 export interface UPMPackage {
@@ -48,22 +50,32 @@ export const getAllPackages = (repositories: VPMRepository[]) => {
     .flatMap(group => getPackages(group));
 }
 
+export const isYanked = (pkg: VPMPackage) => {
+  console.log(`Checking yanked for ${pkg.name}@${pkg.version}`)
+  const yank = pkg['vrc-get']?.['yanked'];
+  const yanked = typeof yank === 'string' || yank === true;
+  console.log(`Yanked: ${yanked}`)
+  return typeof yank === 'string' || yank === true;
+}
+
 /**
  * Return the latest release package. If there are no release packages, return the latest package.
  * @param packages
  * @returns
  */
 export const findLatestReleasePackage = (packages: VPMPackage[]) => {
-  const releasePackages = packages.filter(p => !p.version.includes('-'));
+  const publishingPackages = packages.filter(p => !isYanked(p));
+  const releasePackages = publishingPackages.filter(p => !p.version.includes('-'));
   const latestStable = findLatestPackage(releasePackages);
   if (latestStable) {
     return latestStable;
   }
-  return findLatestPackage(packages);
+  return findLatestPackage(publishingPackages);
 }
 
 export const getPackages = (group: VPMPackageGroup) => {
-  return Object.values(group.versions);
+  return Object.values(group.versions)
+    .filter(p => !isYanked(p))
 }
 
 export const findLatestPackage = (packages: VPMPackage[]) => {


### PR DESCRIPTION
vrc-getではバージョンの取り下げのため、`yank`を実装しています。

`https://vpm.anatawa12.com/vpm.json` では `av3emulator` の初期フォークなど、一部の非推奨なパッケージ/バージョンをvrc-getのyankを用いてALCOM等では非表示にしています。

この pull request では vpm catalog にこれの対応を追加します。
これにより、`DO NOT INSTALL THIS PACKAGE. THIS IS ONLY FOR COMPATIBILITY UNTIL VRCHAT SUPPORTS YANK. (Anatawa12's Modified Av3Emulator)` が表示されなくなります。