### PR TITLE
Add new VPM repositories (2026-04)

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3,6 +3,7 @@ https://aiczk.github.io/VPM/index.json
 https://amarinoa.github.io/AmariNoa-VPM-Listing/index.json
 https://amehuri.github.io/amehuri_tools/index.json
 https://An-Labo.github.io/An-Labo-NailTool/vpm.json
+https://Andrey04o.github.io/Chess04o-vpm/index.json
 https://AnosionV.github.io/vpm/index.json
 https://api.vrlabs.dev/listings/category/Components
 https://api.vrlabs.dev/listings/category/Dependencies
@@ -93,6 +94,7 @@ https://orels1.github.io/orels-Unity-Shaders/index.json
 https://o-tr.github.io/vpm/vpm.json
 https://page.853lab.com/vpm-repos/vpm.json
 https://pandrabox.github.io/vpm/index.json
+https://pesky12.github.io/PeskyBox/index.json
 https://poiyomi.github.io/vpm/index.json
 https://pokeyi.dev/vpm-packages/index.json
 https://prismic247.github.io/ScaledColliderSystem/index.json
@@ -126,6 +128,7 @@ https://scarlet-crystal.github.io/VCC-Package-Listing/index.json
 https://sh0ou.github.io/vpm-repos/vpm.json
 https://sigmal00.github.io/UzumoreShaderVPM/index.json
 https://sinkunvv.github.io/BlendMaestro/index.json
+https://sizimityper.github.io/reflector-shader/index.json
 https://sizimityper.github.io/vpm/index.json
 https://skeb-inc.github.io/skeb-art-panel/index.json
 https://SleetCat123.github.io/vpm-packages/index.json

--- a/repositories.txt
+++ b/repositories.txt
@@ -128,7 +128,6 @@ https://scarlet-crystal.github.io/VCC-Package-Listing/index.json
 https://sh0ou.github.io/vpm-repos/vpm.json
 https://sigmal00.github.io/UzumoreShaderVPM/index.json
 https://sinkunvv.github.io/BlendMaestro/index.json
-https://sizimityper.github.io/reflector-shader/index.json
 https://sizimityper.github.io/vpm/index.json
 https://skeb-inc.github.io/skeb-art-panel/index.json
 https://SleetCat123.github.io/vpm-packages/index.json


### PR DESCRIPTION
直近1か月以内（2026年3月〜4月）に新規公開されたVPMリポジトリを3件追加します。

## 追加リポジトリ

### 1. Pesky's Box（集約: 3+ パッケージ）
**URL**: `https://pesky12.github.io/PeskyBox/index.json`
**発見元**: GitHub API
**収録パッケージ**: `vpm.pesky.box.seatcollisionmanager`, `vpm.pesky.box.easyqualityswitch`, `vpm.pesky.box.badgemanager`
**概要**: VRChatワールド向けの複数ユーティリティパッケージを収録した集約リポジトリ。Seat Collision Managerはシートやテーブルの当たり判定トグルを簡単に設定できるツール、Easy Quality Switchはワールドのグラフィック品質設定ツール、Badge Managerはプレイヤーの頭上にバッジを表示するシステムを提供します。

---

### 2. Chess04o
**URL**: `https://Andrey04o.github.io/Chess04o-vpm/index.json`
**発見元**: GitHub API
**代表パッケージ**: `com.andrey04o.chess04o`
**概要**: UdonSharpで実装されたVRChatワールド向けチェスプレハブ。Udon/UdonSharpを使用したC#製のチェスゲームをVRChatワールドに追加できます。

---

### 3. sizimityper's Reflector Shader
**URL**: `https://sizimityper.github.io/reflector-shader/index.json`
**発見元**: GitHub API
**代表パッケージ**: `com.sizimityper.reflector-shader`
**概要**: VRChatのアバター・ワールド向け反射板シェーダー。反射板のような光反射効果を実現するShaderLabシェーダーで、MIT licenseで公開されています。