### PR TITLE
Add new VPM repositories (2026-04-29)

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -11,6 +11,8 @@ https://api.vrlabs.dev/listings/category/Dependencies
 https://api.vrlabs.dev/listings/category/Essentials
 https://api.vrlabs.dev/listings/category/Rehosted
 https://api.vrlabs.dev/listings/category/Systems
+https://aramaa-vr.github.io/vpm-repos/vpm.json
+https://aurorakai.github.io/vpm/index.json
 https://autch.github.io/VRC_PopulateScaleAdjusters/index.json
 https://awa-vr.github.io/vrc-tools-vpm/index.json
 https://azukimochi.github.io/vpm-repos/index.json
@@ -111,6 +113,7 @@ https://raw.githubusercontent.com/AzuriteLab/azlab_vrc_repos/master/index.json
 https://raw.githubusercontent.com/ksrgtech/vpm-repository/refs/heads/live/index.json
 https://raw.githubusercontent.com/Tsukina-7mochi/glitch-shader/main/vpm.json
 https://raw.githubusercontent.com/Tsukina-7mochi/qvpen-safe-delete/main/vpm.json
+https://raw.githubusercontent.com/Yunhyuk-Jeong/iyan-vpm/main/vpm.json
 https://rayleonard-collection-r3c.github.io/vpm-package-listing/index.json
 https://r-delta-c.github.io/vpm_repository/index.json
 https://reava.github.io/VPM-Listings/index.json


### PR DESCRIPTION
直近1か月の更新・公開・告知を手掛かりに調査し、未収録の VPM リポジトリを 3 件追加します。

## 追加リポジトリ

### 1. Iyan-Kim VPM Repository（集約: 5 パッケージ）
**URL**: `https://raw.githubusercontent.com/Yunhyuk-Jeong/iyan-vpm/main/vpm.json`
**発見元**: GitHub API
**収録パッケージ**: `com.iyankim.planefittocamera`, `com.iyankim.mablendshapesyncautosetup`, `com.iyankim.hierarchyplusrebone`, `com.iyankim.prefabmaterialremapper`, `com.iyankim.uvmasktool`
**代表パッケージ**: `com.iyankim.hierarchyplusrebone`
**概要**: VRChat 向けの Unity Editor ツールをまとめた集約リポジトリです。カメラ基準の Plane 配置、Modular Avatar の Blendshape Sync 自動設定、Hierarchy 拡張、Prefab のマテリアル差し替え、UV マスク出力など、アバター編集を効率化するツール群を配布しています。

---

### 2. Aramaa VPM Repos（集約: 2 パッケージ）
**URL**: `https://aramaa-vr.github.io/vpm-repos/vpm.json`
**発見元**: GitHub API / プロジェクトの説明サイト
**収録パッケージ**: `jp.aramaa.ochibi-chans-converter-tool`, `jp.aramaa.dakochite-gimmick`
**代表パッケージ**: `jp.aramaa.ochibi-chans-converter-tool`
**概要**: VRChat アバター向けのツールとギミックをまとめたリポジトリです。おちびちゃんズ化ツールは既存アバターを複製して「おちびちゃんズ」向け設定へ変換する Editor 拡張で、だこちてギミックは抱っこ・持ち上げ系のアバターギミックを提供します。

---

### 3. AuroraKai VPM Listing
**URL**: `https://aurorakai.github.io/vpm/index.json`
**発見元**: GitHub API
**代表パッケージ**: `com.aurorakai.sps-tools`
**概要**: SPS Tools を配布する VPM リポジトリです。アバター制作用の補助ツール群を VCC から導入できるようにした単一パッケージ系のリポジトリです。
