### PR TITLE
Add new VPM repositories (2026-05-01)

### DIFF
--- a/repositories-ignore.txt
+++ b/repositories-ignore.txt
@@ -8,6 +8,8 @@ https://project-eauploader.github.io/EAUploader-for-VRChat/registry.json
 https://raw.githubusercontent.com/Cayahuanca/Unity/main/vpm-packages.json
 https://sizimityper.github.io/reflector-shader/index.json # covered by https://sizimityper.github.io/vpm/index.json
 https://t2penbix99wcoxkv3a4g.github.io/VPM.ModularAvatarExtensions/index.json # covered by https://t2penbix99wcoxkv3a4g.github.io/VPM/index.json
+https://t2penbix99wcoxkv3a4g.github.io/VPM.SimpleNightVision/index.json # covered by https://t2penbix99wcoxkv3a4g.github.io/VPM/index.json
+https://t2penbix99wcoxkv3a4g.github.io/VPM.WorldFluid/index.json # covered by https://t2penbix99wcoxkv3a4g.github.io/VPM/index.json
 https://vpm.dreadscripts.com/listings/main.json
 https://vpm.magmamc.dev/index.json
 https://vpm.nadena.dev/vpm-prerelease.json

--- a/repositories.txt
+++ b/repositories.txt
@@ -83,6 +83,7 @@ https://lilxyzw.github.io/vpm-repos/vpm.json
 https://LiveDimensions.github.io/VRRefAssist/index.json
 https://lyrastellate.github.io/vpm-repos/index.json
 https://magmamcnet.github.io/VPM/index.json
+https://marble810.github.io/vpmlist/index.json
 https://mattshark89.github.io/OpenFlight-VRC/index.json
 https://mayoi3.github.io/mayoi-vpm-repo/index.json
 https://meronmks.github.io/vpm/index.json


### PR DESCRIPTION
直近1か月の GitHub API / Yahooリアルタイム検索 / Booth 導線を調査し、未収録の VPM リポジトリを 1 件追加します。

また、Yahoo / Booth 経由で見つかった以下 2 件は、既存の集約リポジトリ `https://t2penbix99wcoxkv3a4g.github.io/VPM/index.json` に収録済みだったため `repositories-ignore.txt` に追記します。

- `https://t2penbix99wcoxkv3a4g.github.io/VPM.SimpleNightVision/index.json`
- `https://t2penbix99wcoxkv3a4g.github.io/VPM.WorldFluid/index.json`

## 追加リポジトリ

### 1. Marble Avatar Tools
**URL**: `https://marble810.github.io/vpmlist/index.json`
**発見元**: GitHub API
**代表パッケージ**: `marble810.marbleavatartoolbox`
**概要**: VRChat アバター改変向けツールを配布する VPM リポジトリです。代表パッケージ Marble Avatar Toolbox は、PhysBone・コライダー・アニメーション周りを含むアバター編集支援ツール群をまとめて導入できます。
