### PR TITLE
Add new VPM repositories (2026-05-08)

### DIFF
--- a/repositories-ignore.txt
+++ b/repositories-ignore.txt
@@ -7,6 +7,7 @@ https://poiyomi.github.io/vpm/index.json
 https://project-eauploader.github.io/EAUploader-for-VRChat/registry.json
 https://raw.githubusercontent.com/Cayahuanca/Unity/main/vpm-packages.json
 https://sizimityper.github.io/reflector-shader/index.json # covered by https://sizimityper.github.io/vpm/index.json
+https://t2penbix99wcoxkv3a4g.github.io/VPM.FaceEmoMMDAutoDisabler/index.json # covered by https://t2penbix99wcoxkv3a4g.github.io/VPM/index.json
 https://t2penbix99wcoxkv3a4g.github.io/VPM.ModularAvatarExtensions/index.json # covered by https://t2penbix99wcoxkv3a4g.github.io/VPM/index.json
 https://t2penbix99wcoxkv3a4g.github.io/VPM.SimpleNightVision/index.json # covered by https://t2penbix99wcoxkv3a4g.github.io/VPM/index.json
 https://t2penbix99wcoxkv3a4g.github.io/VPM.WorldFluid/index.json # covered by https://t2penbix99wcoxkv3a4g.github.io/VPM/index.json

--- a/repositories.txt
+++ b/repositories.txt
@@ -205,6 +205,7 @@ https://vpm.thry.dev/index.json
 https://vpm.udon.zip/index.json
 https://vpm.ureishi.net/repos.json
 https://vpm.vrsl.dev/index.json
+https://vpm.whyknot.dev/index.json
 https://vpm.yukineko.dev/index.json
 https://vrceve.github.io/vrceve-asset/index.json
 https://vrchat.github.io/packages/index.json


### PR DESCRIPTION
直近1か月の GitHub API / Yahooリアルタイム検索 / Booth 導線を調査し、未収録の VPM リポジトリを 1 件追加します。

また、GitHub API で見つかった以下 1 件は既存の集約リポジトリ `https://t2penbix99wcoxkv3a4g.github.io/VPM/index.json` に収録済みだったため `repositories-ignore.txt` に追記します。

- `https://t2penbix99wcoxkv3a4g.github.io/VPM.FaceEmoMMDAutoDisabler/index.json`

## 追加リポジトリ

### 1. WhyKnot Tools（集約: 2 パッケージ）
**URL**: `https://vpm.whyknot.dev/index.json`
**発見元**: GitHub API
**収録パッケージ**: `dev.whyknot.avatar-qol`, `dev.whyknot.vrcfury-qol`
**代表パッケージ**: `dev.whyknot.avatar-qol`
**概要**: VRChat アバター改変向けの Editor 拡張をまとめた集約 VPM リポジトリです。Avatar QoL はウェイトの異常や PhysBone 設定の見直しを支援し、VRCFury QoL は VRCFury コンポーネントの移動・参照置換・トグル設定補助など、アバター制作時の細かな作業を効率化します。
