### PR TITLE
Add new VPM repositories (2026-05-22)

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -24,6 +24,7 @@ https://BlueAmulet.github.io/UdonSharpOptimizer/index.json
 https://CascadianVR.github.io/UnityShapekeySearch/index.json
 https://c-colloid.github.io/PBReplacer-VPM/index.json
 https://ccvrc.github.io/vpm/index.json
+https://chillmix-crypto.github.io/avatarscope-vpm/index.json
 https://Centauri2442.github.io/VRCMasterFailureCheck/index.json
 https://Centauri2442.github.io/VRCNetworkDebugger/index.json
 https://chigirits.github.io/vpm-listing/index.json
@@ -163,6 +164,7 @@ https://uslashdeleted.github.io/vcc-listing/index.json
 https://valenvrc.com/index.json
 https://vavassor.github.io/OrchidSealVPM/index.json
 https://vcc.pawlygon.net/index.json
+https://vcc.raphii.co/index.json
 https://vcc.vrcfury.com
 https://VixenCreations.github.io/VixenToolBox/index.json
 https://vpm.32ba.net/index.json

--- a/repositories.txt
+++ b/repositories.txt
@@ -21,13 +21,13 @@ https://befuddledlabs.github.io/LinuxVRChatSDKPatch/index.json
 https://BefuddledLabs.github.io/OpenSyncDance/index.json
 https://blancrenard.github.io/vpm-NolaTools/index.json
 https://BlueAmulet.github.io/UdonSharpOptimizer/index.json
-https://CascadianVR.github.io/UnityShapekeySearch/index.json
 https://c-colloid.github.io/PBReplacer-VPM/index.json
+https://CascadianVR.github.io/UnityShapekeySearch/index.json
 https://ccvrc.github.io/vpm/index.json
-https://chillmix-crypto.github.io/avatarscope-vpm/index.json
 https://Centauri2442.github.io/VRCMasterFailureCheck/index.json
 https://Centauri2442.github.io/VRCNetworkDebugger/index.json
 https://chigirits.github.io/vpm-listing/index.json
+https://chillmix-crypto.github.io/avatarscope-vpm/index.json
 https://codec-xyz.github.io/photo_frame_manager/index.json
 https://cstria0106.github.io/vpm-repos/index.json
 https://cuebitt.github.io/vpm/index.json


### PR DESCRIPTION
直近1か月の GitHub API 検索を主軸に、Yahooリアルタイム検索と Booth 導線確認も含めて未収録の VPM リポジトリを調査し、追加対象 2 件を `repositories.txt` に反映します。

Yahooリアルタイム検索では既存収録済みの告知や Booth 商品導線も確認しましたが、新たに追加価値のある未収録 JSON URL は見つからなかったため、`repositories-ignore.txt` の更新はありません。

## 追加リポジトリ

### 1. AvatarScope VPM Listing
**URL**: `https://chillmix-crypto.github.io/avatarscope-vpm/index.json`
**発見元**: GitHub API
**代表パッケージ**: `com.chill.avatarscope`
**概要**: VRChat アバター向けの解析・最適化ツール AvatarScope を配布する VPM リポジトリです。代表パッケージは実際のアップロードサイズ確認、非破壊のロスレス最適化、UV を考慮したテクスチャ縮小などを提供し、アバターの容量把握と調整を効率化します。

---

### 2. Raphii's VPM Packages
**URL**: `https://vcc.raphii.co/index.json`
**発見元**: GitHub API
**代表パッケージ**: `co.raphii.vrti.avatarmenu`
**概要**: Raphiiko が公開する VRChat / Unity 向けパッケージ配布用の VPM リポジトリです。代表パッケージの VRTI Avatar Menu は VR Treadmill Interface を VRChat アバターのメニューから操作できる prefab を提供し、Modular Avatar と組み合わせた導入を想定しています。
