### PR TITLE
Add new VPM repositories (2026-06-12)

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,6 +1,7 @@
 https://aariyjp.github.io/vpm-repos/index.json
 https://Adjerry91.github.io/VRCFaceTracking-Templates/index.json
 https://aiczk.github.io/VPM/index.json
+https://akiiray.github.io/vpm-repository/index.json
 https://amarinoa.github.io/AmariNoa-VPM-Listing/index.json
 https://amehuri.github.io/amehuri_tools/index.json
 https://An-Labo.github.io/An-Labo-NailTool/vpm.json
@@ -70,11 +71,13 @@ https://HugPhiluu.github.io/PhilSort/index.json
 https://illusive-isc.github.io/vpm-repos/index.json
 https://jazjasmine.github.io/VCC/index.json
 https://JeTeeS.github.io/TES-VPM-Package-Listing/index.json
+https://k3sra.github.io/vrsive-avatar-exporter/index.json
 https://k4584587.github.io/Modular-Auto-Toggle/index.json
 https://kakunpc.github.io/kakunpc_vpm/index.json
 https://kb10uy.github.io/vrc-repository/index.json
 https://kemocade.github.io/Kemocade.Vrc.Data.Extensions/index.json
 https://KitKat4191.github.io/JetSim-VCC-Listing/index.json
+https://kohchaaa.github.io/vpm-repos/vpm.json
 https://kurone-kito.github.io/vpm/index.json
 https://kurotu.github.io/vpm-repos/vpm.json
 https://kxn4t.github.io/vpm-repos/index.json
@@ -102,6 +105,7 @@ https://moruton1119.github.io/com.morulab.unity-tools/index.json
 https://naari3.github.io/mesh-dent/vpm.json
 https://natanetoon.com/index.json
 https://neuru5278.github.io/main-vpm-repos/index.json
+https://nickel-jp.github.io/avatar-recovery-unity/index.json
 https://nidonocu.github.io/virtual-gryphon-packages/index.json
 https://null-k.github.io/vpm-listing/index.json
 https://nullclone.github.io/vpm-listing/index.json


### PR DESCRIPTION
## 新規VPMリポジトリの追加

直近1か月に発見された新しいVPMリポジトリを4つ追加します。

### 集約的リポジトリ

#### 1. Kohchaaa VPM Repository
- **URL**: https://kohchaaa.github.io/vpm-repos/vpm.json
- **パッケージ**: 3つ
  - **jp.kohchaaa.window-locker** (v1.0.0-1.0.1)
    - UnityのInspectorやProjectウィンドウなどをロックできるショートカットを追加
  - **jp.kohchaaa.kohcha-ui** (v0.0.1-0.0.3)
    - Unityエディタ用UI コンポーネント
  - **jp.kohchaaa.avatar-hierarchy-formatter** (v0.0.0-0.0.2)
    - アバターの階層を整形するエディタツール

### 単一パッケージリポジトリ

#### 2. Akiiray VPM Repository
- **URL**: https://akiiray.github.io/vpm-repository/index.json
- **パッケージ**: com.akiiray.vrc-avatar-toolkit-plus (v0.1.0-0.2.5)
- **説明**: VRChatアバターのセットアップ、メンテナンス、デバッグツール

#### 3. VRSive Avatar Exporter
- **URL**: https://k3sra.github.io/vrsive-avatar-exporter/index.json
- **パッケージ**: com.vrsive.avatar-exporter (v2.0.0-2.1.0)
- **説明**: UnityアバターをVRSive avatar package形式でエクスポート。メッシュ、スケルトン、ブレンドシェイプ、マテリアル、テクスチャ、アニメーション、表情、トグル、ダイナミクスメタデータ、オーディオを含む

#### 4. Avatar Recovery Unity
- **URL**: https://nickel-jp.github.io/avatar-recovery-unity/index.json
- **パッケージ**: com.nickel-jp.avatar-recovery (v1.0.0-1.0.4)
- **説明**: VRCA/VRCWファイルからVRChatアバター・ワールドアセットを復元するUnityエディタツール

## 発見方法

- GitHub API による検索（`vpm+vrchat`, `vpm+avatar`, など）
- 直近1か月の更新範囲内で検索
- 各候補URL を `web_fetch` で検証

## 検証

すべてのリポジトリは以下の条件を満たしています：
- ✓ VPM JSON形式が有効
- ✓ GitHub Pages で配信されている
- ✓ 有効なパッケージを含む
- ✓ repositories.txt に未記載

