### PR TITLE
Add new VPM repositories (2026-07-17)

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -36,6 +36,7 @@ https://cstria0106.github.io/vpm-repos/index.json
 https://cuebitt.github.io/vpm/index.json
 https://cyanlaser.github.io/CyanPlayerObjectPool/index.json
 https://cyanlaser.github.io/CyanTrigger/index.json
+https://cympfh.cc/vpm/index.json
 https://d4rkc0d3r.github.io/vpm-repos/main.json
 https://deltaneverused.github.io/VRChatPackages/index.json
 https://dine-png.github.io/Di_Ne_Tool/index.json
@@ -200,6 +201,7 @@ https://vpm.kwxxw.net/index.json
 https://vpm.limitex.dev/index.json
 https://vpm.logilabo.dev/avatars.json
 https://vpm.m4rshal.com/vpm.json
+https://vpm.maaaaa.net/index.json
 https://vpm.matcha-soft.com/repos.json
 https://vpm.micksam7.com/index.json
 https://vpm.mimylab.com/index.json
@@ -242,4 +244,5 @@ https://xtlcdn.github.io/vpm/index.json
 https://yoridrill.github.io/vpm-repos/vpm.json
 https://yueby.github.io/vpm-listing/index.json
 https://z3y.github.io/vpm-package-listing/index.json
+https://zenithval.github.io/vpm/index.json
 https://zwihanderai.github.io/vpm-repos/index.json


### PR DESCRIPTION
## 新規発見VPMリポジトリ

直近1か月（2026-06-17以降）の更新によって発見された新規VPMリポジトリを追加します。

### 1. Poyotoron's VPM Repository（集約: 2パッケージ）
**URL**: `https://vpm.maaaaa.net/index.json`
**発見元**: GitHub API
**収録パッケージ**: `net.maaaaa.asset-keshichaumon-nator`, `net.maaaaa.asset-sanshounaosu-nator`
**代表パッケージ**: `net.maaaaa.asset-keshichaumon-nator`
**概要**: 未使用アセット検出・退避ツール、アセット参照修正ツールなど、VRChatアバター制作向けアセット管理ツールをまとめて配布しています。

---

### 2. cympfh's VPM Repository
**URL**: `https://cympfh.cc/vpm/index.json`
**発見元**: GitHub API
**代表パッケージ**: `cc.cympfh.vrchat-scripts`
**概要**: VRChatアバター・ワールド制作用のUnity Editor スクリプト集。制作効率化ツール群を提供します。

---

### 3. ZenithVal's VPM Repository（集約: 2パッケージ）
**URL**: `https://zenithval.github.io/vpm/index.json`
**発見元**: GitHub API
**収録パッケージ**: `io.github.zenithval.vrc-bulk-upload`, `io.github.zenithval.zeni-avatar-ndmf`
**代表パッケージ**: `io.github.zenithval.vrc-bulk-upload`
**概要**: VRChatアバター一括アップロードツール、Modular Avatar連携ツールなど、VRChatアバター制作ワークフロー向けのツールを配布しています。