### PR TITLE
Add new VPM repositories (2026-08-28)

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -113,6 +113,7 @@ https://mametsubu8.github.io/vpm-listing/vpm.json
 https://marble810.github.io/vpmlist/index.json
 https://mattshark89.github.io/OpenFlight-VRC/index.json
 https://mayoi3.github.io/mayoi-vpm-repo/index.json
+https://meadowsage.github.io/mashirotheater-vpm/index.json
 https://meatwo310.net/vpm/index.json
 https://meronmks.github.io/vpm/index.json
 https://miner28.github.io/MinerPackages/index.json
@@ -168,6 +169,7 @@ https://rollphes.github.io/vpm-repos/vpm.json
 https://rroki-0u0.github.io/vpm-repos/index.json
 https://rurre.github.io/vpm/index.json
 https://RykerTM.github.io/vpm-listing/index.json
+https://sabas0ba.github.io/vrc_sabashader/index.json
 https://sack-kazu.github.io/vpm-repository/index.json
 https://sanaehururu1200.github.io/ma-suimin_system/index.json
 https://saphiblue.github.io/vcc-listing/index.json
@@ -232,6 +234,7 @@ https://vpm.limitex.dev/index.json
 https://vpm.logilabo.dev/avatars.json
 https://vpm.m4rshal.com/vpm.json
 https://vpm.maaaaa.net/index.json
+https://vpm.magmamc.dev/index.json
 https://vpm.matcha-soft.com/repos.json
 https://vpm.micksam7.com/index.json
 https://vpm.mimylab.com/index.json
@@ -248,6 +251,7 @@ https://vpm.raitichan.net/vpm.json
 https://vpm.razgriz.one/index.json
 https://vpm.rerac.dev/index.json
 https://vpm.rs64.net/vpm.json
+https://vpm.sleightly.dev/index.json
 https://vpm.smisann.net/vpm.json
 https://vpm.techanon.dev/index.json
 https://vpm.thry.dev/index.json
@@ -261,6 +265,7 @@ https://vrc-staples.github.io/VRCUnityDevTools/index.json
 https://vrceve.github.io/vrceve-asset/index.json
 https://vrchat-community.github.io/vpm-listing-curated/index.json
 https://vrchat.github.io/packages/index.json
+https://VRCLearn.github.io/filamented/index.json
 https://vrctxl.github.io/VPM/index.json
 https://vrsuya.com/vpm/vpm.json
 https://wagunasu812.github.io/vpm-listing/index.json
@@ -276,6 +281,7 @@ https://xtlcdn.github.io/vpm/index.json
 https://yato96fox.github.io/UnityExpansion-Release/index.json
 https://YerGodDamnRight.github.io/YGDR-VPM-Listing/index.json
 https://yoridrill.github.io/vpm-repos/vpm.json
+https://you5248.github.io/vpm-listing/index.json
 https://yueby.github.io/vpm-listing/index.json
 https://z3y.github.io/vpm-package-listing/index.json
 https://zenithval.github.io/vpm/index.json


### PR DESCRIPTION
## 新規発見VPMリポジトリ（直近1か月）

### 集約的リポジトリ（複数パッケージ）

#### 1. Magma's Packages（5 パッケージ）
**URL**: https://vpm.magmamc.dev/index.json
**収録パッケージ**: 
- `net.magma-mc.shaders` - SRP向けシェーダー集
- `net.magma-mc.utils` - UdonSharp ユーティリティ
- `dev.magmamc.permissionmanager` - 権限管理ツール
- `net.magma-mc.world-shaders` - ワールド向けシェーダー
- `dev.magmamc.materialswitcher` - マテリアル切り替えツール

**概要**: VRChat ワールド・アバター制作向けの実用的なシェーダーとUdonSharp スクリプトを集約したリポジトリ。SRP シェーダーから軽量なスクリプトユーティリティまで幅広い開発ツールを配布している。

---

#### 2. Mashiro Small Theater（2 パッケージ）
**URL**: https://meadowsage.github.io/mashirotheater-vpm/index.json
**収録パッケージ**:
- `com.mashirotheater.common` - 共有シェーダー・マテリアル・フォント
- `com.mashirotheater.utils` - AutoDoor 等の小規模ギミック集

**概要**: ワールド制作向けの共有リソースとギミック詰め合わせ。自動ドア等の実用的なギミックが含まれている。

---

#### 3. JustSleightly's VPM Packages（2 パッケージ）
**URL**: https://vpm.sleightly.dev/index.json
**概要**: Unity エディター効率化ツール等を配布。

---

### 単一パッケージリポジトリ

#### 4. you5248 VPM Listing
**URL**: https://you5248.github.io/vpm-listing/index.json
**パッケージ**: `com.you5248.dhk-shaders`
**概要**: VRChat ワールド向けの軽量 Standard 互換シェーダー。Unity ビルトイン(BiRP/Forward) に最適化され、ライトマップのバイキュービック補間や VRC Light Volumes に対応。Quest 向け軽量版も同梱。

---

#### 5. SabaShader
**URL**: https://sabas0ba.github.io/vrc_sabashader/index.json
**パッケージ**: `io.github.sabas0ba.sabashader`
**概要**: Shader Core をベースにした VRChat 向けシェーダー集。2D イラスト風トゥーンシェーダー Illust2D が第一弾。Apache-2.0 ライセンスで公開。

---

#### 6. Filamented | VRCLearn
**URL**: https://VRCLearn.github.io/filamented/index.json
**パッケージ**: `s-ilent.filamented`
**概要**: Google Filament レンダラーのシェーダーを Unity Standard シェーダーのフレームワークに移植した高品質シェーディングシステム。

---

## 発見方法
GitHub API による直近1か月の更新検索（2026-07-28 以降に push されたリポジトリを対象）。