### PR TITLE
Add new VPM repositories (2026-09-04)

### DIFF
--- a/repositories-ignore.txt
+++ b/repositories-ignore.txt
@@ -43,7 +43,7 @@ https://u-kotovsky.github.io/vpm-listing/index.json # only contains VRChat SDK p
 https://uslashdeleted.github.io/vcc-listing/index.json # github user not found
 https://vpm.dreadscripts.com/listings/main.json
 https://vpm.kyre.moe/vpm.json # alias (CNAME) of https://kyure-a.github.io/vpm-repos/vpm.json
-https://vpm.magmamc.dev/index.json
+https://vpm.magmamc.dev/index.json # URL is https://MagmaVRC.github.io/VPM/index.json
 https://vpm.nadena.dev/vpm-prerelease.json
 https://vrchat-community.github.io/template-package-listing/index.json # official VRChat example listing template, not a real listing
 https://vrchat-community.github.io/template-package/index.json # official VRChat example package template, not a real listing

--- a/repositories.txt
+++ b/repositories.txt
@@ -96,7 +96,7 @@ https://kie610.github.io/vpm-listing/index.json
 https://kikurage1989.github.io/ragecraftVPM/index.json
 https://KitKat4191.github.io/JetSim-VCC-Listing/index.json
 https://kohchaaa.github.io/vpm-repos/vpm.json
-https://komugi0906.github.io/vpm-repository/
+https://komugi0906.github.io/vpm-repository/index.json
 https://koz39.github.io/vpm-listing/index.json
 https://kurone-kito.github.io/vpm/index.json
 https://kurotu.github.io/vpm-repos/vpm.json

--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+http://vpm.yuna0x0.com/index.json
 https://aariyjp.github.io/vpm-repos/index.json
 https://Adjerry91.github.io/VRCFaceTracking-Templates/index.json
 https://aiczk.github.io/VPM/index.json
@@ -95,6 +96,7 @@ https://kie610.github.io/vpm-listing/index.json
 https://kikurage1989.github.io/ragecraftVPM/index.json
 https://KitKat4191.github.io/JetSim-VCC-Listing/index.json
 https://kohchaaa.github.io/vpm-repos/vpm.json
+https://komugi0906.github.io/vpm-repository/
 https://koz39.github.io/vpm-listing/index.json
 https://kurone-kito.github.io/vpm/index.json
 https://kurotu.github.io/vpm-repos/vpm.json
@@ -105,11 +107,13 @@ https://LauraRozier.github.io/LauraVRCUtils/index.json
 https://lazyoptimiser.euan.net/index.json
 https://lereldarion.github.io/vpm-listing/index.json
 https://lighfu.github.io/vpm/index.json
+https://lightbulb4.github.io/vpm/index.json
 https://lilxyzw.github.io/vpm-repos-shadercore-modules/vpm.json
 https://lilxyzw.github.io/vpm-repos/vpm.json
 https://LiveDimensions.github.io/VRRefAssist/index.json
 https://LuiStudio.github.io/VPM-Package-Listing/index.json
 https://lyrastellate.github.io/vpm-repos/index.json
+https://MagmaVRC.github.io/VPM/index.json
 https://mametsubu8.github.io/vpm-listing/vpm.json
 https://marble810.github.io/vpmlist/index.json
 https://mattshark89.github.io/OpenFlight-VRC/index.json
@@ -204,6 +208,8 @@ https://tp-jp.github.io/vpm-repos/index.json
 https://Tr1turbo.github.io/BlendShare/index.json
 https://tr1turbo.github.io/vpm-listing/index.json
 https://tsukumodo.github.io/omamori/index.json
+https://Udonite.github.io/vpm/index.json
+https://URektMe.github.io/rainywithin-vpm/index.json
 https://valenvrc.com/index.json
 https://vavassor.github.io/OrchidSealVPM/index.json
 https://vcc.aitsys.dev/index.json

--- a/repositories.txt
+++ b/repositories.txt
@@ -242,7 +242,6 @@ https://vpm.limitex.dev/index.json
 https://vpm.logilabo.dev/avatars.json
 https://vpm.m4rshal.com/vpm.json
 https://vpm.maaaaa.net/index.json
-https://vpm.magmamc.dev/index.json
 https://vpm.matcha-soft.com/repos.json
 https://vpm.micksam7.com/index.json
 https://vpm.mimylab.com/index.json


### PR DESCRIPTION
## 新規VPMリポジトリの追加

直近1か月の探索により、以下の6つの新規VPMリポジトリを発見しました。

### 集約型リポジトリ（複数パッケージ）

#### 1. MagmaVRC/VPM（5パッケージ）
**URL**: `https://MagmaVRC.github.io/VPM/index.json`
**概要**: MagmaVRCによるシェーダー・ユーティリティの集約リポジトリ。複数のシェーディング関連ツールと権限管理ツール、Udon関連プロファイラーを提供します。

**パッケージ**:
- `net.magma-mc.shaders` - シェーダーコレクション
- `net.magma-mc.utils` - ユーティリティツール
- `dev.magmamc.permissionmanager` - 権限管理ツール
- `dev.magmavrc.udonprofiler` - Udonプロファイラー
- `dev.magmavrc.udonvm` - UdonVM

#### 2. URektMe/rainywithin-vpm（3パッケージ）
**URL**: `https://URektMe.github.io/rainywithin-vpm/index.json`
**概要**: URektMeのアバター/ワールド装飾ツール群。衣装や髪型の変更機能、最適化ツールを含む集約リポジトリです。

**パッケージ**:
- `com.rainywithin.outfitlinker` - 衣装リンカー
- `com.rainywithin.hairlinker` - 髪型リンカー
- `com.rainywithin.optimizertools` - 最適化ツール

#### 3. lightbulb4/vpm（2パッケージ）
**URL**: `https://lightbulb4.github.io/vpm/index.json`
**概要**: lightbulb4によるワールド制作向けツール。エリア遮蔽テクニックとワールド管理ツールを提供します。

**パッケージ**:
- `com.lightbulb.arealit-occlusion` - エリア遮蔽ツール
- `com.lightbulb.world-tools` - ワールド管理ツール

### 単一パッケージリポジトリ

#### 4. yuna0x0/vpm-listing
**URL**: `http://vpm.yuna0x0.com/index.json`
**パッケージ**: `com.yuna0x0.basis.convert` - Basis形式変換ツール

#### 5. Udonite/vpm
**URL**: `https://Udonite.github.io/vpm/index.json`
**パッケージ**: `com.udonite.compiler` - UdonSharpコンパイラ

#### 6. komugi0906/vpm-repository
**URL**: `https://komugi0906.github.io/vpm-repository/`
**パッケージ**: `com.komugiluck.earrings` - イヤリングツール

---

### 発見方法
- GitHub API: `vpm+vrchat`, `vpm+package+listing`, `vpm-listing`, `VCC+listing` クエリで検索
- 検索対象期間: 直近1か月（2026-08-04以降の更新）
- URL検証: 各URLのJSONエンドポイントに対してHTTPリクエストを実行し、VPM形式の妥当性を確認

### 変更内容
- `repositories.txt` に6つの新規VPMリポジトリURLを辞書順で追加
- `tasks/sort-repos.sh` で全リポジトリを辞書順に再ソート
