### PR TITLE
Update editorconfig-checker to 6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/semver": "^7.5.8",
     "any-json": "^3.1.0",
     "daisyui": "^4.11.1",
-    "editorconfig-checker": "^6.1.1",
+    "editorconfig-checker": "^6.2.0",
     "eslint": "^10.1.0",
     "eslint-plugin-astro": "^1.6.0",
     "mdast": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^4.11.1
         version: 4.11.1(postcss@8.5.8)
       editorconfig-checker:
-        specifier: ^6.1.1
-        version: 6.1.1
+        specifier: ^6.2.0
+        version: 6.2.0
       eslint:
         specifier: ^10.1.0
         version: 10.1.0(jiti@1.21.0)
@@ -1695,8 +1695,8 @@ packages:
     resolution: {integrity: sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==}
     engines: {node: '>=0.8'}
 
-  editorconfig-checker@6.1.1:
-    resolution: {integrity: sha512-kiOb6qaWpMNt7Z/43ba0Pa1Inhr2/t9nKbvEKtCeXJ5AesztoM9AgLOOQVB4QUv/nGjgz3xkbx4pcogVRD2NWw==}
+  editorconfig-checker@6.2.0:
+    resolution: {integrity: sha512-5zrNwlxUWyOvAcrSK4mPIGNYrf1KK5pH2D3VXDB1AcDsDdBfLNPOjBL5jHgYh+JykOIuXlQHMeYvXPrZwGNmHA==}
     engines: {node: '>=20.11.0'}
     hasBin: true
 
@@ -3418,6 +3418,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -3496,6 +3497,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -5650,7 +5652,7 @@ snapshots:
       errlop: 2.2.0
       semver: 6.3.1
 
-  editorconfig-checker@6.1.1: {}
+  editorconfig-checker@6.2.0: {}
 
   electron-to-chromium@1.5.328: {}
 


### PR DESCRIPTION
The Lint workflow started failing with "The binary 'ec-linux-amd64*' not found". The npm wrapper downloads the latest Go release at runtime, and editorconfig-checker v4.0.0 (2026-09-04) renamed its release assets from ec-<os>-<arch> to editorconfig-checker-<os>-<arch>. Wrapper 6.2.0 looks up the new name with a fallback to the legacy one.

Staying on 6.x because 7.0.0 requires Node.js >= 24.14.0, which conflicts with DEVELOPMENT.md (Node.js 20.3.0 or later) and the devcontainer image (Node.js 22).