### PR TITLE
Add new VPM repositories (2026-09-11)

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -123,6 +123,7 @@ https://meatwo310.net/vpm/index.json
 https://meronmks.github.io/vpm/index.json
 https://miner28.github.io/MinerPackages/index.json
 https://minminmean.github.io/minminmart/index.json
+https://mitsuya0077.github.io/VR-Vlog-lilToon-Exporter/index.json
 https://mmmaellon.github.io/MMMaellonVCCListing/index.json
 https://moruton1119.github.io/com.morulab.unity-tools/index.json
 https://naari3.github.io/mesh-dent/vpm.json
@@ -138,6 +139,7 @@ https://nuruwo8.github.io/nuruwo-vpm-list/index.json
 https://nyakomechan.github.io/vpm-repository/index.json
 https://o-tr.github.io/vpm/vpm.json
 https://omeletteak.github.io/vpm-listing/index.json
+https://orange3134.github.io/vpm/index.json
 https://orels1.github.io/orels-Unity-Shaders/index.json
 https://page.853lab.com/vpm-repos/vpm.json
 https://pandrabox.github.io/vpm/index.json


### PR DESCRIPTION
## 新規発見VPMリポジトリ

### 1. VR Vlog Packages（集約: 3 パッケージ）
**URL**: `https://mitsuya0077.github.io/VR-Vlog-lilToon-Exporter/index.json`
**発見元**: GitHub API
**収録パッケージ**: `com.vrmc.gltf`, `com.vrmc.vrm`, `com.vrvlog.liltoon-vrm-exporter`
**代表パッケージ**: `com.vrvlog.liltoon-vrm-exporter`
**概要**: VRChat制作者向けのVRM・lilToon関連ツール集。UniGLTFインポーター/エクスポーター、VRM-1.0インポーター、そしてVRM 1.0のMToon fallbackおよびlilToon extension対応のエクスポーターを提供します。

---

### 2. pipipigiken Packages（集約: 2 パッケージ）
**URL**: `https://orange3134.github.io/vpm/index.json`
**発見元**: GitHub API
**収録パッケージ**: `com.avatarnamecard.avatar-package`, `com.avatarnamecard.exporter`
**代表パッケージ**: `com.avatarnamecard.exporter`
**概要**: VRChatアバター向けのMEISHI Pop（名刺ポップ）フォーマット関連ツール集。SDK非依存のアバターパッケージ形式定義と、オリジナルマテリアル・シェーダに対応したエクスポーターツールを提供します。